### PR TITLE
Add instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## Setup
 
+### Setup Foundry packages
+
+```
+$ forge install
+```
+
 ### Setup `.env.testnet`
 
 Copy from `.env.testnet.example` and fill the fields:
@@ -48,9 +54,8 @@ Clean resources for testnet:
 make testnet-down
 ```
 
-## Contract Testing
+## Local Contract Testing
 
 ```
-$ forge install
 $ forge test
 ```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 ## Setup
 
-### Setup Foundry packages
-
-```
-$ forge install
-```
-
 ### Setup `.env.testnet`
 
 Copy from `.env.testnet.example` and fill the fields:
@@ -46,8 +40,17 @@ This testnet has following pre-deployed contracts:
 
 The owner of these contracts is `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`, which is the first address derived from testing mnemonic `test test test test test test test test test test test junk`, and it has unlimited balance of ether.
 
+> Please make sure the contracts in the submodules(`lib`) are added into `src/Artifacts.sol` for being compiled.
+
 Clean resources for testnet:
 
 ```bash
 make testnet-down
+```
+
+## Contract Testing
+
+```
+$ forge install
+$ forge test
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## Setup
 
+### Setup Foundry packages
+
+```
+$ forge install
+```
+
 ### Setup `.env.testnet`
 
 Copy from `.env.testnet.example` and fill the fields:


### PR DESCRIPTION
- There is no package setup instruction in `README.md`, I think add this short command is more clear. 