### PR TITLE
Fix no matching manifest for arm64/v8 from the docker image of foundry

### DIFF
--- a/docker/testnet/docker-compose.yml
+++ b/docker/testnet/docker-compose.yml
@@ -32,6 +32,7 @@ services:
 
   geth_setup:
     image: ghcr.io/foundry-rs/foundry
+    platform: linux/amd64
     working_dir: /waallet-contract
     depends_on:
       - geth


### PR DESCRIPTION
# Description
- When running `make testnet-up`, the docker image of foundry cannot build successfully due to `no matching manifest for linux/arm64/v8 in the manifest list entries`.
- Same issue reported in foundry-rs: [docker image: no matching manifest for linux/arm64/v8 in the manifest list entries](https://github.com/foundry-rs/foundry/issues/7680)

# Changes
- Add `platform: linux/amd64` 